### PR TITLE
fix bug ISS-1399 and ISS-1404

### DIFF
--- a/src/main/java/cz/it4i/parallel/runners/logging/ui/FeedbackMessage.java
+++ b/src/main/java/cz/it4i/parallel/runners/logging/ui/FeedbackMessage.java
@@ -1,9 +1,16 @@
+
 package cz.it4i.parallel.runners.logging.ui;
 
-
 public class FeedbackMessage {
-	
-	public FeedbackMessage() {
-		// This is empty on purpose.
+
+	private boolean windowIsOpen;
+
+	public FeedbackMessage(boolean isOpen) {
+		windowIsOpen = isOpen;
 	}
+
+	public boolean getWindowIsOpen() {
+		return windowIsOpen;
+	}
+
 }

--- a/src/main/java/cz/it4i/parallel/runners/logging/ui/LogWindowRedirectingOutputService.java
+++ b/src/main/java/cz/it4i/parallel/runners/logging/ui/LogWindowRedirectingOutputService.java
@@ -5,6 +5,7 @@
  * This file is subject to the terms and conditions defined in
  * file 'LICENSE', which is part of this project.
  ******************************************************************************/
+
 package cz.it4i.parallel.runners.logging.ui;
 
 import com.google.common.eventbus.DeadEvent;
@@ -21,7 +22,6 @@ import cz.it4i.parallel.runners.OutputSource;
 public class LogWindowRedirectingOutputService extends
 	BaseRedirectingOutputService implements RedirectedOutputService
 {
-
 
 	private EventBus eventBus = new EventBus("redirectedOutputBus");
 
@@ -92,7 +92,11 @@ public class LogWindowRedirectingOutputService extends
 		 */
 		@Subscribe
 		public void handleListening(FeedbackMessage message) {
-			outputSources.forEach(s -> s.statusOfOutputChanged(true));
+			if (message.getWindowIsOpen()) {
+				outputSources.forEach(s -> s.statusOfOutputChanged(true));
+			} else {
+				outputSources.forEach(s -> s.statusOfOutputChanged(false));
+			}
 		}
 
 	}

--- a/src/main/java/cz/it4i/parallel/runners/logging/ui/RedirectedOutputScreenController.java
+++ b/src/main/java/cz/it4i/parallel/runners/logging/ui/RedirectedOutputScreenController.java
@@ -26,7 +26,7 @@ public class RedirectedOutputScreenController extends AnchorPane {
 		this.redirectedOutput = redirectedOutput;
 		JavaFXRoutines.initRootAndController("redirected-output-screen.fxml", this);
 		redirectedOutput.register(this);
-		redirectedOutput.post(new FeedbackMessage());
+		redirectedOutput.post(new FeedbackMessage(true));
 	}
 
 	public void initialize() {
@@ -45,6 +45,7 @@ public class RedirectedOutputScreenController extends AnchorPane {
 	}
 
 	public void close() {
+		redirectedOutput.post(new FeedbackMessage(false));
 		redirectedOutput.unregister(this);
 	}
 }


### PR DESCRIPTION
fix bug where the whole output is not displayed when window is already open before activation of the paradigm by running the threads in the beginning to account for the possibility that a window is already listening.